### PR TITLE
Helping contents and results

### DIFF
--- a/backend/AtlasBackend/src/AtlasGraph/src/AtlasGraph.jl
+++ b/backend/AtlasBackend/src/AtlasGraph/src/AtlasGraph.jl
@@ -87,7 +87,7 @@ function filternodes(
 end
 
 function updategraph!(graph::AbstractGraph)::AbstractGraph
-    data_nodes = filternodes(graph.nodes, Union{TextNode})
+    data_nodes = filternodes(graph.nodes, TextNode)
 
     expressions = filternodes(graph.nodes, AbstractExpressionNode)
     ordered_nodes = FormulaUtils.topological_order(

--- a/backend/AtlasBackend/src/AtlasGraph/src/AtlasGraph.jl
+++ b/backend/AtlasBackend/src/AtlasGraph/src/AtlasGraph.jl
@@ -4,7 +4,6 @@ export AbstractEdge, ProviderEdge
 export AbstractNode, Node
 export AbstractContentNode
 export AbstractTextNode, TextNode
-export AbstractFileNode, FileNode
 export AbstractFunctionNode, FunctionNode
 export AbstractExpressionNode, ExpressionNode
 
@@ -26,18 +25,14 @@ mutable struct TextNode <: AbstractTextNode
     content::String
 end
 
-abstract type AbstractFileNode <: AbstractContentNode end
-mutable struct FileNode <: AbstractFileNode
-    node::Node
-    content::String
-    filename::String
-end
-
 abstract type AbstractExpressionNode <: AbstractContentNode end
 mutable struct ExpressionNode <: AbstractExpressionNode
     node::Node
     content::String
     result::Any
+    error::Any
+    helper_contents::Vector{String}
+    helper_results::Vector{Any}
 end
 
 abstract type AbstractFunctionNode <: AbstractContentNode end
@@ -92,7 +87,7 @@ function filternodes(
 end
 
 function updategraph!(graph::AbstractGraph)::AbstractGraph
-    data_nodes = filternodes(graph.nodes, Union{FileNode,TextNode})
+    data_nodes = filternodes(graph.nodes, Union{TextNode})
 
     expressions = filternodes(graph.nodes, AbstractExpressionNode)
     ordered_nodes = FormulaUtils.topological_order(

--- a/backend/AtlasBackend/src/AtlasGraph/src/utils/interactions/JsonUtils.jl
+++ b/backend/AtlasBackend/src/AtlasGraph/src/utils/interactions/JsonUtils.jl
@@ -42,11 +42,16 @@ function node(json_dict::JSON3.Object)::AbstractNode
     if json_dict["type"] == string(Node)
         return node
     elseif json_dict["type"] == string(ExpressionNode)
-        return ExpressionNode(node, json_dict["content"], nothing)
+        return ExpressionNode(
+            node,
+            json_dict["content"],
+            nothing,
+            nothing,
+            json_dict["helper_contents"],
+            [],
+        )
     elseif json_dict["type"] == string(TextNode)
         return TextNode(node, json_dict["content"])
-    elseif json_dict["type"] == string(FileNode)
-        return FileNode(node, json_dict["content"], json_dict["filename"])
     end
 end
 

--- a/backend/AtlasBackend/src/AtlasGraph/src/utils/interactions/JsonUtils.jl
+++ b/backend/AtlasBackend/src/AtlasGraph/src/utils/interactions/JsonUtils.jl
@@ -25,10 +25,6 @@ function dictionary(node::AbstractNode)::Dict{AbstractString,Any}
     return dic
 end
 
-function get_human_readable_string(value::Any)::String
-    return sprint(show, "text/plain", value)
-end
-
 function json(node::AbstractNode)::JSON3.Object
     return jsonwriteread(push!(dictionary(node), "type" => typeof(node)))
 end

--- a/backend/AtlasBackend/src/AtlasGraph/src/utils/interactions/JsonUtils.jl
+++ b/backend/AtlasBackend/src/AtlasGraph/src/utils/interactions/JsonUtils.jl
@@ -13,7 +13,11 @@ function dictionary(node::AbstractNode)::Dict{AbstractString,Any}
         if (typeof(value) <: AbstractNode)
             merge!(dic, dictionary(value))
         elseif field == :result
-            push!(dic, string(field) => string(value))
+            push!(dic, string(field) => sprint(show, "text/plain", value))
+        elseif field == :helper_results
+            push!(dic, string(field) => map(val -> sprint(show, "text/plain", val), value))
+        elseif field == :error
+            push!(dic, string(field) => sprint(showerror, value))
         else
             push!(dic, string(field) => value)
         end
@@ -21,6 +25,9 @@ function dictionary(node::AbstractNode)::Dict{AbstractString,Any}
     return dic
 end
 
+function get_human_readable_string(value::Any)::String
+    return sprint(show, "text/plain", value)
+end
 
 function json(node::AbstractNode)::JSON3.Object
     return jsonwriteread(push!(dictionary(node), "type" => typeof(node)))

--- a/backend/AtlasBackend/src/AtlasGraph/src/utils/kernels/execution/Executer.jl
+++ b/backend/AtlasBackend/src/AtlasGraph/src/utils/kernels/execution/Executer.jl
@@ -3,15 +3,26 @@ using ..AtlasGraph, ..Functions
 using ResultTypes
 
 function execute_node(node::ExpressionNode)
+    node.result = nothing
+    node.error = nothing
+    node.helper_results = Vector{Any}(nothing, length(node.helper_contents))
+
     try
         eval(Expr(:(=), node.name, Meta.parse(node.content)))
         node.result = eval(node.name)
     catch e
-        node.result = e
+        node.error = e
+    end
+
+    try
+        for i = 1:length(node.helper_contents)
+            node.helper_results[i] = eval(Meta.parse(node.helper_contents[i]))
+        end
+    catch e
     end
 end
 
-function execute_node(node::Union{FileNode,TextNode})
+function execute_node(node::Union{TextNode})
     try
         eval(Expr(:(=), node.name, node.content))
     catch e

--- a/backend/AtlasBackend/src/AtlasGraph/src/utils/parser/Tokens.jl
+++ b/backend/AtlasBackend/src/AtlasGraph/src/utils/parser/Tokens.jl
@@ -4,7 +4,10 @@ export getnames
 
 function getnames(content::String)::Set{Symbol}
     list = []
-    postwalk(x -> x isa Symbol ? (push!(list, x); x) : x, Meta.parse(content))
+    try
+        postwalk(x -> x isa Symbol ? (push!(list, x); x) : x, Meta.parse(content))
+    catch ignored
+    end
     return Set{Symbol}(list)
 end
 

--- a/backend/AtlasBackend/src/AtlasGraph/test/TestUtils.jl
+++ b/backend/AtlasBackend/src/AtlasGraph/test/TestUtils.jl
@@ -31,13 +31,10 @@ function gentext(name::Symbol, content::AbstractString)::TextNode
     return TextNode(gennode(name), content)
 end
 
-function genfile(name::Symbol, content::AbstractString, filename::AbstractString)::FileNode
-    return FileNode(gennode(name), content, filename)
+function genexpression(name::Symbol, content::AbstractString, result::Any)::ExpressionNode
+    return ExpressionNode(gennode(name), content, result, nothing, [], [])
 end
 
-function genexpression(name::Symbol, content::AbstractString, result::Any)::ExpressionNode
-    return ExpressionNode(gennode(name), content, result)
-end
 function genexpression(name::Symbol, content::AbstractString)::ExpressionNode
     return genexpression(name, content, nothing)
 end

--- a/backend/AtlasBackend/src/AtlasGraph/test/runtests.jl
+++ b/backend/AtlasBackend/src/AtlasGraph/test/runtests.jl
@@ -1,4 +1,5 @@
 include("./TestUtils.jl")
+include("./utils/kernels/execution/ExecuterTest.jl")
 include("./utils/parser/TokensTest.jl")
 include("./AtlasGraphTest.jl")
 include("./utils/interactions/JsonUtilsTest.jl")

--- a/backend/AtlasBackend/src/AtlasGraph/test/utils/interactions/JsonUtilsTest.jl
+++ b/backend/AtlasBackend/src/AtlasGraph/test/utils/interactions/JsonUtilsTest.jl
@@ -4,61 +4,24 @@ import .TestUtils as tu
 using JSON3
 
 @testset "JsonUtils" begin
-    @testset "to JSON" begin
-        begin
-            node = Node(:name, "data")
-            node_json = """{"name":"name","uidata":"data","type":"Node"}"""
-            @test JsonUtils.json(node) == JSON3.read(node_json)
-        end
-        begin
-            node = TextNode(Node(:name, "data"), "foo")
-            node_json = """{"name":"name","content":"foo","uidata":"data","type":"TextNode"}"""
-            @test JsonUtils.json(node) == JSON3.read(node_json)
-        end
-        begin
-            node = ExpressionNode(Node(:name, "data"), "1 + 2", 3)
-            node_json = """{"name":"name","content":"1 + 2","uidata":"data","type":"ExpressionNode","result":"3"}"""
-            @test JsonUtils.json(node) == JSON3.read(node_json)
-        end
-        begin
-            node1 = Node(:name1, "data")
-            node2 = ExpressionNode(Node(:name2, "data"), "name1", 3)
-            graph = Graph([node1, node2])
-            graph_json =
-                """{"nodes":[{"name":"name1","uidata":"data","type":"Node"},""" *
-                """{"name":"name2","uidata":"data","content":"name1","type":"ExpressionNode","result":"3"}]""" *
-                ""","name":"graph","edges":[{"from":"name1","to":"name2"}]}"""
-            @test JsonUtils.json(graph) == JSON3.read(graph_json)
-        end
-
-        begin
-            edge = ProviderEdge(:ex1, :ex2)
-            edge_json = """{"from":"ex1","to":"ex2"}"""
-            @test JsonUtils.json(edge) == JSON3.read(edge_json)
-        end
+    begin
+        node = tu.gennode(:name)
+        @test JsonUtils.node(JsonUtils.json(node)) ≂ node
     end
+    begin
+        node = tu.genexpression(:name, "1 + 2")
+        @test JsonUtils.node(JsonUtils.json(node)) ≂ node
+    end
+    begin
+        node = tu.gentext(:name, "foo")
+        @test JsonUtils.node(JsonUtils.json(node)) ≂ node
+    end
+    begin
+        node1 = tu.gennode(:name1)
+        node2 = tu.genexpression(:name2, "1 + 2")
+        graph = Graph([node1, node2])
+        actual = JsonUtils.graph(JsonUtils.json(graph))
 
-
-    @testset "from JSON" begin
-        begin
-            node = tu.gennode(:name)
-            @test JsonUtils.node(JsonUtils.json(node)) ≂ node
-        end
-        begin
-            node = tu.genexpression(:name, "1 + 2")
-            @test JsonUtils.node(JsonUtils.json(node)) ≂ node
-        end
-        begin
-            node = tu.genfile(:name, "foo", "bar.txt")
-            @test JsonUtils.node(JsonUtils.json(node)) ≂ node
-        end
-        begin
-            node1 = tu.gennode(:name1)
-            node2 = tu.genexpression(:name2, "1 + 2")
-            graph = Graph([node1, node2])
-            actual = JsonUtils.graph(JsonUtils.json(graph))
-
-            @test tu.equals(graph, actual)
-        end
+        @test tu.equals(graph, actual)
     end
 end

--- a/backend/AtlasBackend/src/AtlasGraph/test/utils/kernels/execution/ExecuterTest.jl
+++ b/backend/AtlasBackend/src/AtlasGraph/test/utils/kernels/execution/ExecuterTest.jl
@@ -1,0 +1,46 @@
+using AtlasGraph, AtlasGraph.Executer
+using Test, .TestUtils
+import .TestUtils as tu
+
+@testset "Executer" begin
+    begin
+        node = tu.genexpression(:name, "10")
+        Executer.execute_node(node)
+        @test node.error === nothing
+        @test node.result === 10
+        @test Executer.name === 10
+    end
+    begin
+        node = tu.genexpression(:name, "\"")
+        Executer.execute_node(node)
+        @test node.result === nothing
+        @test typeof(node.error) == ErrorException
+    end
+    begin
+        node = tu.genexpression(:name, "print(\"{\"foo\":5}\")")
+        Executer.execute_node(node)
+        @test node.result === nothing
+        @test typeof(node.error) == Base.Meta.ParseError
+    end
+    begin
+        node = ExpressionNode(Node(:name, ""), "", nothing, nothing, ["5+5"], [nothing])
+        Executer.execute_node(node)
+        @test node.result === nothing
+        @test node.error === nothing
+        @test node.helper_results == [10]
+    end
+    begin
+        node = ExpressionNode(
+            Node(:name, ""),
+            "",
+            nothing,
+            nothing,
+            ["5+5", "sin(5)"],
+            [nothing],
+        )
+        Executer.execute_node(node)
+        @test node.result === nothing
+        @test node.error === nothing
+        @test node.helper_results == [10, sin(5)]
+    end
+end

--- a/frontend/components/blocks/UiNode.tsx
+++ b/frontend/components/blocks/UiNode.tsx
@@ -38,7 +38,6 @@ export function TextBlock({ data }: { data: { node: TextNode } }) {
 
 export function FileBlock({ data }: { data: { node: FileNode } }) {
 	const [contentToShow, setContentToShow] = useState<string | null>(null);
-	const [importedFileName, setImportedFileName] = useState<string>(data.node.filename);
 
 	const uploadFile = (event: React.ChangeEvent<HTMLInputElement>) => {
 		if (event.target.files === null) return;
@@ -46,7 +45,7 @@ export function FileBlock({ data }: { data: { node: FileNode } }) {
 			event.target.files[0],
 			(content: string) => (data.node.content = content),
 		);
-		setImportedFileName(event.target.files[0].name);
+		data.node.setFilename(event.target.files[0].name);
 	};
 
 	const showFileContent = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -57,7 +56,7 @@ export function FileBlock({ data }: { data: { node: FileNode } }) {
 		data.node.name,
 		<>
 			<input className={styles.inputFile} type="file" onChange={uploadFile} />
-			<div className={styles.importedFiletext}>Imported file: {importedFileName}</div>
+			<div className={styles.importedFiletext}>Imported file: {data.node.filename}</div>
 			<label>
 				<input className={styles.inputFile} type="checkbox" onChange={showFileContent} />{' '}
 				Show content

--- a/frontend/components/blocks/UiNode.tsx
+++ b/frontend/components/blocks/UiNode.tsx
@@ -5,15 +5,16 @@ import { ExpressionNode, TextNode, FileNode } from '../../utils/AtlasGraph';
 import FileUtils from '../../utils/FileUtils';
 
 export const uiNodeTypes = {
-	[ExpressionNode.type]: ExpressionBlock,
-	[TextNode.type]: TextBlock,
-	[FileNode.type]: FileBlock,
+	[ExpressionNode.uitype]: ExpressionBlock,
+	[TextNode.uitype]: TextBlock,
+	[FileNode.uitype]: FileBlock,
 };
 
 export function UiBlockWrapper(
 	name: string,
 	content: JSX.Element | string,
 	result: string | null = null,
+	error: string | null = null,
 ): JSX.Element {
 	return (
 		<div className={styles.block}>
@@ -22,6 +23,11 @@ export function UiBlockWrapper(
 			<div className={styles.name}>{name}</div>
 			<div className={styles.contentWrapper}>{content}</div>
 			<div className={result !== null ? styles.result : ''}>{result}</div>
+			<div
+				className={error !== null && error !== 'nothing' ? styles.error : styles.invisible}
+			>
+				{error}
+			</div>
 		</div>
 	);
 }
@@ -31,7 +37,7 @@ export function TextBlock({ data }: { data: { node: TextNode } }) {
 }
 
 export function FileBlock({ data }: { data: { node: FileNode } }) {
-	const [contentToShow, setcontentToShow] = useState<string | null>(null);
+	const [contentToShow, setContentToShow] = useState<string | null>(null);
 	const [importedFileName, setImportedFileName] = useState<string>(data.node.filename);
 
 	const uploadFile = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -44,7 +50,7 @@ export function FileBlock({ data }: { data: { node: FileNode } }) {
 	};
 
 	const showFileContent = (event: React.ChangeEvent<HTMLInputElement>) => {
-		event.target.checked ? setcontentToShow(data.node.content) : setcontentToShow(null);
+		event.target.checked ? setContentToShow(data.node.content) : setContentToShow(null);
 	};
 
 	return UiBlockWrapper(
@@ -62,5 +68,5 @@ export function FileBlock({ data }: { data: { node: FileNode } }) {
 }
 
 export function ExpressionBlock({ data }: { data: { node: ExpressionNode } }) {
-	return UiBlockWrapper(data.node.name, data.node.content, data.node.result);
+	return UiBlockWrapper(data.node.name, data.node.content, data.node.result, data.node.error);
 }

--- a/frontend/components/document/ElementsPanel.tsx
+++ b/frontend/components/document/ElementsPanel.tsx
@@ -23,7 +23,7 @@ export default function ElementsPanel({ wiu }: Props) {
 		return (
 			<div key={node.getId()} className={selectedStyle} onClick={selectElement}>
 				<span className={styles.elementName}>{node.name}</span>
-				<span>: {getNodeTypeName(node.type)}</span>
+				<span>: {getNodeTypeName(node.uitype)}</span>
 			</div>
 		);
 	}

--- a/frontend/styles/Block.module.css
+++ b/frontend/styles/Block.module.css
@@ -8,13 +8,22 @@
 	font-size: 14px;
 }
 
-.result {
+.result,
+.error {
 	background-color: rgba(236, 236, 236, 0.8);
 	font-size: 12px;
 	text-align: left;
 	padding: 10px;
 	border-bottom-left-radius: 3px;
 	border-bottom-right-radius: 3px;
+}
+
+.invisible {
+	display: none;
+}
+
+.error {
+	background-color: rgba(255, 220, 220, 0.8);
 }
 
 .name {

--- a/frontend/utils/AtlasGraph.ts
+++ b/frontend/utils/AtlasGraph.ts
@@ -71,32 +71,24 @@ export class AtlasEdge {
 }
 
 export class AtlasNode {
-	static type: string = 'AtlasGraph.Node';
-	public type: string;
-	static uitype: string = AtlasNode.type;
+	static uitype: string = 'AtlasGraph.Node';
 
-	public uitype: string;
 	public name: string;
+	public type: string;
+	public uitype: string;
 	public position: [number, number];
 	public visibility: boolean;
 
-	constructor(
-		type: string,
-		name: string,
-		uitype: string,
-		position: [number, number],
-		visibility: boolean,
-	) {
-		this.type = type;
-		this.uitype = uitype;
-		this.name = name;
-		this.uitype = uitype;
-		this.position = position;
-		this.visibility = visibility;
+	constructor() {
+		this.name = '';
+		this.type = AtlasNode.uitype;
+		this.uitype = AtlasNode.uitype;
+		this.position = [0, 0];
+		this.visibility = true;
 	}
 
 	public static build() {
-		return new AtlasNode('', '', '', [0, 0], true);
+		return new AtlasNode();
 	}
 
 	public setDefaultName(graph: AtlasGraph) {
@@ -116,13 +108,13 @@ export class AtlasNode {
 		});
 	}
 
-	public setType(type: string): AtlasNode {
-		this.type = type;
+	public setName(name: string): AtlasNode {
+		this.name = name;
 		return this;
 	}
 
-	public setName(name: string): AtlasNode {
-		this.name = name;
+	public setUitype(visibility: boolean): AtlasNode {
+		this.visibility = visibility;
 		return this;
 	}
 
@@ -130,18 +122,19 @@ export class AtlasNode {
 		this.position = [x, y];
 		return this;
 	}
+
+	public setVisibility(visibility: boolean): AtlasNode {
+		this.visibility = visibility;
+		return this;
+	}
 }
 
 export class ContentNode extends AtlasNode {
 	public content: string;
 
-	constructor(node: AtlasNode, content: string) {
-		super(node.type, node.name, node.uitype, node.position, node.visibility);
-		this.content = content;
-	}
-
-	public static build() {
-		return new TextNode(AtlasNode.build(), '');
+	constructor() {
+		super();
+		this.content = '';
 	}
 
 	public setContent(content: string): ContentNode {
@@ -151,56 +144,54 @@ export class ContentNode extends AtlasNode {
 }
 
 export class TextNode extends ContentNode {
-	static type = 'AtlasGraph.TextNode';
-	static uitype = TextNode.type;
+	static uitype = 'AtlasGraph.TextNode';
 
-	constructor(node: AtlasNode, content: string) {
-		super(node, content);
-		this.type = TextNode.type;
+	constructor() {
+		super();
+		this.type = TextNode.uitype;
 		this.uitype = TextNode.uitype;
-	}
-}
-
-export class FileNode extends AtlasNode {
-	static type = 'AtlasGraph.FileNode';
-	static uitype = FileNode.type;
-	public content: string;
-	public filename: string;
-
-	constructor(node: AtlasNode, content: string, filename: string) {
-		super(FileNode.type, node.name, FileNode.uitype, node.position, node.visibility);
-		this.content = content;
-		this.filename = filename;
 	}
 
 	public static build() {
-		return new FileNode(AtlasNode.build(), '', '');
+		return new TextNode();
+	}
+}
+
+export class FileNode extends ContentNode {
+	static uitype = 'AtlasGraph.FileNode';
+	public filename: string;
+
+	constructor() {
+		super();
+		this.type = FileNode.uitype;
+		this.uitype = FileNode.uitype;
+		this.filename = '';
+	}
+
+	public static build() {
+		return new FileNode();
 	}
 }
 
 export class ExpressionNode extends ContentNode {
-	static type = 'AtlasGraph.ExpressionNode';
-	static uitype = ExpressionNode.type;
+	static uitype = 'AtlasGraph.ExpressionNode';
 	public result: string;
+	public error: string;
+	public helper_contents: string[];
+	public helper_results: string[];
 
-	constructor(node: AtlasNode, content: string, result: string) {
-		super(node, content);
-		this.type = ExpressionNode.type;
+	constructor() {
+		super();
+		this.type = ExpressionNode.uitype;
 		this.uitype = ExpressionNode.uitype;
-		this.result = result;
+		this.result = 'nothing';
+		this.error = 'nothing';
+		this.helper_contents = [];
+		this.helper_results = [];
 	}
 
 	public static build() {
-		return new ExpressionNode(AtlasNode.build(), '', '');
-	}
-
-	public static buildWithUitype(uitype: string) {
-		switch (uitype) {
-			case MatrixFilterNode.uitype:
-				return MatrixFilterNode.build();
-			default:
-				return ExpressionNode.build();
-		}
+		return new ExpressionNode();
 	}
 
 	public setResult(result: string): ExpressionNode {
@@ -212,12 +203,12 @@ export class ExpressionNode extends ContentNode {
 export class MatrixFilterNode extends ExpressionNode {
 	static uitype: string = 'MatrixFilterNode';
 
-	constructor(node: AtlasNode, content: string, result: string) {
-		super(node, content, result);
+	constructor() {
+		super();
 		this.uitype = MatrixFilterNode.uitype;
 	}
 
 	public static build(): MatrixFilterNode {
-		return new MatrixFilterNode(AtlasNode.build(), '', '');
+		return new MatrixFilterNode();
 	}
 }

--- a/frontend/utils/AtlasGraph.ts
+++ b/frontend/utils/AtlasGraph.ts
@@ -87,25 +87,25 @@ export class AtlasNode {
 		this.visibility = true;
 	}
 
-	public static build() {
+	public static build(): AtlasNode {
 		return new AtlasNode();
 	}
 
-	public setDefaultName(graph: AtlasGraph) {
+	public setDefaultName(graph: AtlasGraph): AtlasNode {
 		this.name = graph.getDefaultName();
 		return this;
 	}
 
-	public getId() {
+	public getId(): string {
 		return this.name;
 	}
 
-	public getUiData() {
-		return JSON.stringify({
+	public getUiData(): object {
+		return {
 			uitype: this.uitype,
 			position: this.position,
 			visibility: this.visibility,
-		});
+		};
 	}
 
 	public setName(name: string): AtlasNode {
@@ -152,24 +152,32 @@ export class TextNode extends ContentNode {
 		this.uitype = TextNode.uitype;
 	}
 
-	public static build() {
+	public static build(): TextNode {
 		return new TextNode();
 	}
 }
 
-export class FileNode extends ContentNode {
+export class FileNode extends TextNode {
 	static uitype = 'AtlasGraph.FileNode';
 	public filename: string;
 
 	constructor() {
 		super();
-		this.type = FileNode.uitype;
 		this.uitype = FileNode.uitype;
 		this.filename = '';
 	}
 
-	public static build() {
+	public static build(): FileNode {
 		return new FileNode();
+	}
+
+	public getUiData(): object {
+		return { ...super.getUiData(), filename: this.filename };
+	}
+
+	public setFilename(filename: string): FileNode {
+		this.filename = filename;
+		return this;
 	}
 }
 
@@ -190,7 +198,7 @@ export class ExpressionNode extends ContentNode {
 		this.helper_results = [];
 	}
 
-	public static build() {
+	public static build(): ExpressionNode {
 		return new ExpressionNode();
 	}
 

--- a/frontend/utils/JsonUtils.ts
+++ b/frontend/utils/JsonUtils.ts
@@ -36,11 +36,11 @@ export default class JsonUtils {
 	}
 
 	private static readonly typeMap = {
-		[ExpressionNode.uitype]: () => ExpressionNode.build(),
-		[MatrixFilterNode.uitype]: () => MatrixFilterNode.build(),
-		[TextNode.uitype]: () => TextNode.build(),
-		[FileNode.uitype]: () => FileNode.build(),
-		[AtlasNode.uitype]: () => AtlasNode.build(),
+		[ExpressionNode.uitype]: ExpressionNode.build,
+		[MatrixFilterNode.uitype]: MatrixFilterNode.build,
+		[TextNode.uitype]: TextNode.build,
+		[FileNode.uitype]: FileNode.build,
+		[AtlasNode.uitype]: AtlasNode.build,
 	};
 
 	public static extractNodes(nodes: {}[]): AtlasNode[] {

--- a/frontend/utils/JsonUtils.ts
+++ b/frontend/utils/JsonUtils.ts
@@ -68,7 +68,7 @@ export default class JsonUtils {
 	}
 
 	private static getNodeToJsonString(node: AtlasNode, space?: number): string {
-		return JSON.stringify({ ...node, uidata: node.getUiData() }, null, space);
+		return JSON.stringify({ ...node, uidata: JSON.stringify(node.getUiData()) }, null, space);
 	}
 
 	private static jsonStringifyReplacer(key: string, value: any) {

--- a/frontend/utils/JsonUtils.ts
+++ b/frontend/utils/JsonUtils.ts
@@ -1,4 +1,11 @@
-import AtlasGraph, { AtlasEdge, AtlasNode, ExpressionNode, TextNode, FileNode } from './AtlasGraph';
+import AtlasGraph, {
+	AtlasEdge,
+	AtlasNode,
+	ExpressionNode,
+	TextNode,
+	FileNode,
+	MatrixFilterNode,
+} from './AtlasGraph';
 
 export default class JsonUtils {
 	public static jsonToGraph(graphJson: {
@@ -14,6 +21,7 @@ export default class JsonUtils {
 				.setEdges(this.extractEdges(graphJson.edges));
 		} catch (e) {
 			window.alert(`This JSON is not an AtlasGraph: ${e}`);
+			console.log(graphJson);
 		}
 		return new AtlasGraph();
 	}
@@ -28,10 +36,11 @@ export default class JsonUtils {
 	}
 
 	private static readonly typeMap = {
-		[ExpressionNode.type]: (uitype: string) => ExpressionNode.buildWithUitype(uitype),
-		[TextNode.type]: (uitype: string) => TextNode.build(),
-		[FileNode.type]: (uitype: string) => FileNode.build(),
-		[AtlasNode.type]: (uitype: string) => AtlasNode.build(),
+		[ExpressionNode.uitype]: () => ExpressionNode.build(),
+		[MatrixFilterNode.uitype]: () => MatrixFilterNode.build(),
+		[TextNode.uitype]: () => TextNode.build(),
+		[FileNode.uitype]: () => FileNode.build(),
+		[AtlasNode.uitype]: () => AtlasNode.build(),
 	};
 
 	public static extractNodes(nodes: {}[]): AtlasNode[] {
@@ -44,11 +53,12 @@ export default class JsonUtils {
 
 	public static extractNode(node: any): AtlasNode {
 		Object.assign(node);
-		if (this.typeMap[node.type] == undefined) {
-			throw new Error('no such node type: ' + node.type);
-		}
 		Object.assign(node, JSON.parse(node.uidata));
-		return Object.assign(this.typeMap[node.type](node.uitype), node);
+		if (this.typeMap[node.uitype] == undefined) {
+			console.log(node);
+			throw new Error('no such node uitype: ' + node.uitype);
+		}
+		return Object.assign(this.typeMap[node.uitype](), node);
 	}
 
 	public static extractEdges(edges: object[]): AtlasEdge[] {

--- a/frontend/utils/WebInterfaceUtils.ts
+++ b/frontend/utils/WebInterfaceUtils.ts
@@ -40,7 +40,7 @@ export default class WebInterfaceUtils {
 	public static toUiNode(node: AtlasNode): UINode {
 		return {
 			id: node.getId(),
-			type: node.type,
+			type: node.uitype,
 			position: { x: node.position[0], y: node.position[1] },
 			data: { node: node },
 			hidden: !node.visibility,


### PR DESCRIPTION
- `helper_contents` & `helper_results`
- refactored frontend nodes constructors
- got rid of `FileNodes` on backend (FileNode still present on frontend)
- replaced `types` with `uitypes` on frontend
- pretty display of results and errors
- fixed a few bugs
<img width="557" alt="Screenshot 2022-06-16 at 22 33 27" src="https://user-images.githubusercontent.com/61039123/174158822-b343a832-b2f7-484c-8aba-b02a2ae8da66.png">

